### PR TITLE
Fix search in personal names

### DIFF
--- a/rundatanet/runes/js/index_scripts.js
+++ b/rundatanet/runes/js/index_scripts.js
@@ -833,7 +833,6 @@ export function inscriptions2markup(inscriptions) {
 
       if (shouldHighlight && inscriptionData.hasOwnProperty('matchDetails') && inscriptionData.matchDetails.hasOwnProperty('wordIndices')) {
         const entryWordBoundaries = inscriptionData[`${columnName}_word_boundaries`];
-        console.log(`entryWordBoundaries: ${JSON.stringify(entryWordBoundaries)}`);
         const matchedWords = inscriptionData.matchDetails.wordIndices;
         const matchedWordBoundaries = entryWordBoundaries.filter((_, i) => matchedWords.includes(i));
         columnData = highlightWordsFromWordBoundaries(columnData, matchedWordBoundaries);

--- a/rundatanet/runes/js/index_view_model.js
+++ b/rundatanet/runes/js/index_view_model.js
@@ -21,6 +21,14 @@ export class RunicViewModel {
     return ids.map(id => this.dbMap.get(parseInt(id, 10)));
   }
   
+  /**
+   * Retrieves all inscriptions from the database map.
+   * @returns {Iterator} An iterator over all values in the database map.
+   */
+  getAllInscriptions() {
+    return this.dbMap.values();
+  }
+
   // Get all currently active inscriptions (filtered by search if a search is active)
   getActiveInscriptions() {
     if (this.searchResults) {
@@ -56,7 +64,8 @@ export class RunicViewModel {
     // Notify subscribers that data has changed
     $(document).trigger('viewModelUpdated', { 
       source: 'search',
-      count: this.searchResults.size 
+      count: this.searchResults.size,
+      model: this
     });
   }
 
@@ -67,7 +76,8 @@ export class RunicViewModel {
     
     $(document).trigger('viewModelUpdated', { 
       source: 'reset',
-      count: this.dbMap.size 
+      count: this.dbMap.size,
+      model: this
     });
   }
   

--- a/rundatanet/templates/runes/index_new.html
+++ b/rundatanet/templates/runes/index_new.html
@@ -686,7 +686,7 @@ function isSafari() {
 <script type="text/javascript">
 let gSqlDb = null;
 let gJsTreeInscriptions = [];
-let gDbMap = {}; // Map object. Key - inscription ID, value - inscription object.
+// let gDbMap = {}; // Map object. Key - inscription ID, value - inscription object.
 let gAllMarkers = null; // Mapping of all leaflet markers. Key - inscription ID, value - object with keys 'found', 'present'.
 let gMyMap = null;
 let gMarkersLayer = null;
@@ -703,13 +703,13 @@ function getCrossUrl(crossName) {
 $('#loading').hide();
 
 function onDbLoaded() {
-  gDbMap = convertDbToKeyMap(gSqlDb);
-  gViewModel = new RunicViewModel(gDbMap);
-  gAllMarkers = inscriptions2markers(gDbMap, L);
+  const dbMap = convertDbToKeyMap(gSqlDb);
+  gViewModel = new RunicViewModel(dbMap);
+  gAllMarkers = inscriptions2markers(dbMap, L);
   //inscriptions2Select(document.getElementById('inpInscriptions'), gDbMap);
   // gJsTreeInscriptions = inscriptions2treeNodes(dbJson);
-  initQueryBuilder(inpQueryBuilder, gDbMap, getHumanName);
-  calcWordsAndPersonalNames(gDbMap.values());
+  initQueryBuilder(inpQueryBuilder, dbMap, getHumanName);
+  calcWordsAndPersonalNames(gViewModel.getAllInscriptions());
 
   // populate jstree with data
   $('#jstree').jstree(true).refresh();  
@@ -841,16 +841,13 @@ document.addEventListener('DOMContentLoaded', function() {
 
   document.getElementById('btnSearch').addEventListener('click', function() {
     const rules = $(`#${inpQueryBuilder}`).queryBuilder('getRules');
-    const results = doSearch(rules, gDbMap.values());
+    const results = doSearch(rules, gViewModel.getAllInscriptions());
     console.log(`Got ${results.length} results`);
     gViewModel.setSearchResults(results);
-
-    calcWordsAndPersonalNames(results);    
   });
 
   document.getElementById('btnResetSearch').addEventListener('click', function() {
     gViewModel.clearSearchResults();
-    calcWordsAndPersonalNames(gDbMap.values());
   });
 
   // Search statistics updates:
@@ -866,6 +863,7 @@ document.addEventListener('DOMContentLoaded', function() {
   $(document).on('viewModelUpdated', function(event, data) {
     $('#jstree').jstree(true).refresh(false, true);
     showMarkersWrapper();
+    calcWordsAndPersonalNames(data.model.getActiveInscriptions());
   });
 
 });


### PR DESCRIPTION
* Sunset gDbMap in favour of gViewModel.
* Fixed search in personal names. Firstly, started to use correct rule key to define whether user would like to exclude or include personal names. Secondly, add functionality, which allows to search in (multi-)personal names with operators like begins with. The use case can be a word like this `"Eynd/"Eyind/"Eyvind/"Vetr/"Hvít`. Here, a search begins with 'Ve' resulted in no hits before. It will correctly find 'Vetr' now. We still treat such name variants as a single name and the whole string will be highlighted.