### PR TITLE
Fix search imports; fix search via year; add full address

### DIFF
--- a/rundatanet/runes/js/index_query_builder.js
+++ b/rundatanet/runes/js/index_query_builder.js
@@ -17,6 +17,7 @@ const optGroups = {
     "sv": "Signatura",
   },
   "gr_texts": "Texts",
+  "gr_location": "Location",
   "other": "---",
 };
 
@@ -321,10 +322,9 @@ function prepareAutoComplete(ruleId, dbMap, humanNameGetter, opt = {}) {
   }
   
   const fieldId = opt.fieldId || ruleId;
-  const operators = opt.operators || ["my_contains", "my_not_contains",
-        'my_equal', 'my_not_equal', 'my_begins_with',
-        "my_not_begins_with", "my_ends_with",
-        "my_not_ends_with", "is_empty", 'is_not_empty'];
+  const operators = opt.operators || ["contains", "not_contains",
+        'equal', 'not_equal', 'begins_with', "not_begins_with",
+        "ends_with", "not_ends_with", "is_empty", 'is_not_empty'];
   const type = opt.type || 'string';
   const size = opt.size || 100;
   const optgroup = opt.optgroup || "other";
@@ -346,7 +346,7 @@ function prepareAutoComplete(ruleId, dbMap, humanNameGetter, opt = {}) {
       attachToParent: true,
     },
     size: size,
-    // operators: operators,
+    operators: operators,
   }
 }
 
@@ -576,7 +576,7 @@ export function initQueryBuilder(containerId, viewModel, getHumanName) {
   
   let queryBuilderFilters = [
     {
-      id: 'signature_text',
+      id: 'inscription_id',
       optgroup: 'gr_signature',
       field: 'signature_text',
       label: getHumanName('signature_text'),
@@ -607,7 +607,7 @@ export function initQueryBuilder(containerId, viewModel, getHumanName) {
     },
     prepareAutoComplete('carver', dbMap, getHumanName),
     {
-      id: 'signature_country',
+      id: 'inscription_country',
       optgroup: "gr_signature",
       field: 'signature_text',
       label: 'Country or Swedish province',
@@ -657,13 +657,14 @@ export function initQueryBuilder(containerId, viewModel, getHumanName) {
     prepareAutoComplete('english_translation', dbMap, getHumanName, { optgroup: 'gr_texts' }),
     prepareAutoComplete('swedish_translation', dbMap, getHumanName, { optgroup: 'gr_texts' }),
 
-    prepareAutoComplete('found_location', dbMap, getHumanName),
-    prepareAutoComplete('parish', dbMap, getHumanName),
-    prepareAutoComplete('district', dbMap, getHumanName),
-    prepareAutoComplete('municipality', dbMap, getHumanName),
-    prepareAutoComplete('current_location', dbMap, getHumanName),
+    prepareAutoComplete('full_address', dbMap, getHumanName, { optgroup: 'gr_location', operators: ['contains'] }),
+    prepareAutoComplete('found_location', dbMap, getHumanName, { optgroup: 'gr_location' }),
+    prepareAutoComplete('parish', dbMap, getHumanName, { optgroup: 'gr_location' }),
+    prepareAutoComplete('district', dbMap, getHumanName, { optgroup: 'gr_location' }),
+    prepareAutoComplete('municipality', dbMap, getHumanName, { optgroup: 'gr_location' }),
+    prepareAutoComplete('current_location', dbMap, getHumanName, { optgroup: 'gr_location' }),
     prepareAutoComplete('original_site', dbMap, getHumanName),
-    prepareAutoComplete('parish_code', dbMap, getHumanName),
+    prepareAutoComplete('parish_code', dbMap, getHumanName, { optgroup: 'gr_location' }),
     prepareAutoComplete('rune_type', dbMap, getHumanName),
     prepareAutoComplete('dating', dbMap, getHumanName),
     prepareIntegerRule('year_from', dbMap, getHumanName, { operators: ['equal', 'less', 'greater', 'between'] }),
@@ -781,7 +782,7 @@ export function initQueryBuilder(containerId, viewModel, getHumanName) {
 
   // Event handler when rule is created and rule operator is changed
   $('#builder').on('afterCreateRuleInput.queryBuilder afterUpdateRuleOperator.queryBuilder', function(e, rule) {
-    if (rule.filter.id !== 'signature_text') {
+    if (rule.filter.id !== 'inscription_id') {
       return;
     }
     adjustTomSelectAndAutoComplete(rule, signature_text_tomselect_cfg, signature_text_autocomplete_cfg);

--- a/rundatanet/runes/js/index_query_builder.js
+++ b/rundatanet/runes/js/index_query_builder.js
@@ -591,16 +591,8 @@ export function initQueryBuilder(containerId, viewModel, getHumanName) {
       ],
       valueSetter: function (rule, value) {
         const $input = rule.$el.find('.rule-value-container input');
-        const operator = rule.operator.type;
-        if (operator === 'in' || operator === 'not_in') {
-          $input.tomSelect('setValue', value);
-        } else {
-          if ($input[0].autoComplete) {
-            $input[0].autoComplete.setValue(value);
-          } else {
-            $input.val(value);
-          }
-        }
+        $input.val(value);
+        adjustTomSelectAndAutoComplete(rule, signature_text_tomselect_cfg, signature_text_autocomplete_cfg);
       },
       plugin: 'tomSelect',
       plugin_config: signature_text_tomselect_cfg,

--- a/rundatanet/runes/js/index_scripts.js
+++ b/rundatanet/runes/js/index_scripts.js
@@ -6,6 +6,12 @@ export const schemaFieldsInfo = [
     },
   },
   {
+    schemaName: 'full_address',
+    text: {
+      'en': 'Full address',
+    },
+  },
+  {
     schemaName: 'found_location',
     text: {
       'en': 'Found location',

--- a/rundatanet/runes/js/index_search.js
+++ b/rundatanet/runes/js/index_search.js
@@ -239,6 +239,11 @@ export class QueryBuilderParser {
       return { match: false };
     }
 
+    if (typeof ruleValue === 'number' && fieldValue === '') {
+      // Handle case where fieldValue is an empty string but ruleValue is a number
+      return { match: false };
+    }
+
     // Apply the operator and normalize the result
     const result = this.operators[operatorName](fieldValue, ruleValue);
     const isMatch = Boolean(result);
@@ -449,7 +454,7 @@ const searchCountryOrProvince = (entry, ruleValues) => {
 }
 
 const customSearchFunctions = {
-  signature_text: {
+  inscription_id: {
     in: (record, ruleValue) => searchSignatureWrapper(record, ruleValue, operators.equal),
     in_separated_list: (record, ruleValue) => searchSignatureWrapper(record, ruleValue, operators.equal),
     begins_with: (record, ruleValue) => searchSignatureWrapper(record, ruleValue, operators.begins_with),
@@ -461,7 +466,7 @@ const customSearchFunctions = {
     equal: (record, ruleValue) => searchSignatureWrapper(record, ruleValue, operators.equal),
     not_equal: (record, ruleValue) => searchSignatureWrapper(record, ruleValue, operators.not_equal),
   },
-  signature_country: {
+  inscription_country: {
     in: searchCountryOrProvince,
   },
   normalization_norse_to_transliteration: {

--- a/rundatanet/tests/js/index_search.test.js
+++ b/rundatanet/tests/js/index_search.test.js
@@ -148,6 +148,7 @@ function testSingleRuleSearch({
 }
 
 testSingleRuleSearch({
+  id: 'inscription_id',
   operator: 'in',
   value: 'Öl 1',
   expectedCount: 1,
@@ -156,6 +157,7 @@ testSingleRuleSearch({
   multiField: true,
 });
 testSingleRuleSearch({
+  id: 'inscription_id',
   operator: 'in',
   value: ['Öl 1', 'Öl 2'],
   expectedCount: 2,
@@ -163,12 +165,14 @@ testSingleRuleSearch({
   multiField: true,
 });
 testSingleRuleSearch({
+  id: 'inscription_id',
   operator: 'in_separated_list',
   value: 'Öl 1|Öl 2|Öl 12',
   expectedCount: 3,
   multiField: true,
 });
 testSingleRuleSearch({
+  id: 'inscription_id',
   operator: 'begins_with',
   value: 'Öl 1',
   expectedCount: 11,
@@ -176,6 +180,7 @@ testSingleRuleSearch({
   multiField: true,
 });
 testSingleRuleSearch({
+  id: 'inscription_id',
   operator: 'not_begins_with',
   value: 'Öl 1',
   expectedCount: 6804,
@@ -183,6 +188,7 @@ testSingleRuleSearch({
   multiField: true,
 });
 testSingleRuleSearch({
+  id: 'inscription_id',
   operator: 'ends_with',
   value: '4',
   expectedCount: 1026,
@@ -190,6 +196,7 @@ testSingleRuleSearch({
   multiField: true,
 });
 testSingleRuleSearch({
+  id: 'inscription_id',
   operator: 'not_ends_with',
   value: '4',
   expectedCount: 5789,
@@ -197,6 +204,7 @@ testSingleRuleSearch({
   multiField: true,
 });
 testSingleRuleSearch({
+  id: 'inscription_id',
   operator: 'contains',
   value: 'Öl',
   expectedCount: 190,
@@ -204,6 +212,7 @@ testSingleRuleSearch({
   multiField: true,
 });
 testSingleRuleSearch({
+  id: 'inscription_id',
   operator: 'not_contains',
   value: 'Öl',
   expectedCount: 6625,
@@ -213,7 +222,7 @@ testSingleRuleSearch({
 
 
 testSingleRuleSearch({
-  id: 'signature_country',
+  id: 'inscription_country',
   field: 'signature_text',
   operator: 'in',
   value: ['Öl', 'Sm'],
@@ -222,7 +231,7 @@ testSingleRuleSearch({
   multiField: true,
 });
 testSingleRuleSearch({
-  id: 'signature_country',
+  id: 'inscription_country',
   field: 'signature_text',
   operator: 'in',
   value: ['all_sweden'],
@@ -277,5 +286,38 @@ testSingleRuleSearch({
   multiField: false,
   firstResultCheck: 1100,
 });
+
+test('search inscription via year range', () => {
+  const multiField = false;
+  const rules = {
+    condition: "AND",
+    rules: [
+      {
+        id: "year_from",
+        field: "year_from",
+        operator: "greater",
+        value: 1099,
+        data: multiField ? { multiField: true } : {}
+      },
+      {
+        id: "year_to",
+        field: "year_to",
+        operator: "less",
+        value: 1101,
+        data: multiField ? { multiField: true } : {}
+      },
+    ],
+    not: false,
+    valid: true
+  };
+  
+  const results = doSearch(rules, dbMap.values());
+  const expectedCount = 48;
+  
+  assert.not(results[0].signature_text === 'Ög 218', 'Should not find Ög 218');
+  assert.is(results.length, expectedCount, `Should find ${expectedCount} inscriptions`);
+});
+
+
 
 test.run();

--- a/rundatanet/tests/js/index_search.test.js
+++ b/rundatanet/tests/js/index_search.test.js
@@ -73,18 +73,47 @@ test('highlightWordsFromWordBoundaries with no boundaries', () => {
   assert.is(result, expected, 'Should return original string when no boundaries are provided');
 });
 
-function testInscriptionSearch({
+
+// Helper function to create a readable string representation of the search value
+function getValueAsString(value) {
+  if (value === null) {
+    return 'null';
+  } else if (Array.isArray(value)) {
+    return '[' + value.map(v => `"${v}"`).join(', ') + ']';
+  } else if (typeof value === 'object') {
+    return JSON.stringify(value);
+  } else {
+    return `"${value}"`;
+  }
+}
+
+/**
+ * Test function for searching inscriptions using a single rule
+ * 
+ * @param {Object} options - The options for the search test
+ * @param {string} options.operator - The operator to use for the search rule (e.g., 'equal', 'contains')
+ * @param {*} options.value - The value to search for
+ * @param {number} options.expectedCount - The number of results expected to be found
+ * @param {string} [options.testName] - Custom name for the test (defaults to a generated name using field and operator)
+ * @param {string|null} [options.id] - Custom id for the rule (defaults to field name)
+ * @param {*} [options.firstResultCheck] - Value to check against the first result's field (if provided)
+ * @param {boolean} [options.multiField=false] - Whether the search rule is multi-field or not
+ * @param {string} [options.condition='AND'] - The condition to use for combining rules
+ * @param {string} [options.field='signature_text'] - The field to search in
+ * @returns {void}
+ */
+function testSingleRuleSearch({
   operator, 
   value, 
   expectedCount, 
   testName,
   id = null,
   firstResultCheck = null,
-  multiField = true,
+  multiField = false,
   condition = 'AND',
   field = 'signature_text'
 }) {
-  test(testName || `search inscription via ${operator} (${value})`, () => {
+  test(testName || `search inscription via ${field}::${operator} (${getValueAsString(value)})`, () => {
     const rules = {
       condition: condition,
       rules: [
@@ -107,68 +136,83 @@ function testInscriptionSearch({
     assert.is(result.length, expectedCount, `Should find ${expectedCount} inscriptions`);
     
     if (firstResultCheck) {
-      assert.is(result[0][field], firstResultCheck, `First result should be ${firstResultCheck}`);
+      if (typeof firstResultCheck === 'object') {
+        const fieldDataStr = JSON.stringify(result[0][field]);
+        const firstResultCheckStr = JSON.stringify(firstResultCheck);
+        assert.is(fieldDataStr, firstResultCheckStr, `First result should be ${firstResultCheckStr}`);
+      } else {
+        assert.is(result[0][field], firstResultCheck, `First result should be ${firstResultCheck}`);
+      }
     }
   });
 }
 
-testInscriptionSearch({
+testSingleRuleSearch({
   operator: 'in',
   value: 'Öl 1',
   expectedCount: 1,
   testName: 'search one inscription',
-  firstResultCheck: 'Öl 1'
+  firstResultCheck: 'Öl 1',
+  multiField: true,
 });
-testInscriptionSearch({
+testSingleRuleSearch({
   operator: 'in',
   value: ['Öl 1', 'Öl 2'],
   expectedCount: 2,
-  testName: 'search multiple inscriptions by id'
+  testName: 'search multiple inscriptions by id',
+  multiField: true,
 });
-testInscriptionSearch({
+testSingleRuleSearch({
   operator: 'in_separated_list',
   value: 'Öl 1|Öl 2|Öl 12',
   expectedCount: 3,
+  multiField: true,
 });
-testInscriptionSearch({
+testSingleRuleSearch({
   operator: 'begins_with',
   value: 'Öl 1',
   expectedCount: 11,
-  firstResultCheck: 'Öl 1'
+  firstResultCheck: 'Öl 1',
+  multiField: true,
 });
-testInscriptionSearch({
+testSingleRuleSearch({
   operator: 'not_begins_with',
   value: 'Öl 1',
   expectedCount: 6804,
-  firstResultCheck: 'Öl 2'
+  firstResultCheck: 'Öl 2',
+  multiField: true,
 });
-testInscriptionSearch({
+testSingleRuleSearch({
   operator: 'ends_with',
   value: '4',
   expectedCount: 1026,
-  firstResultCheck: 'Öl 2'
+  firstResultCheck: 'Öl 2',
+  multiField: true,
 });
-testInscriptionSearch({
+testSingleRuleSearch({
   operator: 'not_ends_with',
   value: '4',
   expectedCount: 5789,
-  firstResultCheck: 'Öl 1'
+  firstResultCheck: 'Öl 1',
+  multiField: true,
 });
-testInscriptionSearch({
+testSingleRuleSearch({
   operator: 'contains',
   value: 'Öl',
   expectedCount: 190,
-  firstResultCheck: 'Öl 1'
+  firstResultCheck: 'Öl 1',
+  multiField: true,
 });
-testInscriptionSearch({
+testSingleRuleSearch({
   operator: 'not_contains',
   value: 'Öl',
   expectedCount: 6625,
-  firstResultCheck: 'Ög 1'
+  firstResultCheck: 'Ög 1',
+  multiField: true,
 });
 
 
-testInscriptionSearch({
+testSingleRuleSearch({
   id: 'signature_country',
   field: 'signature_text',
   operator: 'in',
@@ -177,7 +221,7 @@ testInscriptionSearch({
   firstResultCheck: 'Öl 1',
   multiField: true,
 });
-testInscriptionSearch({
+testSingleRuleSearch({
   id: 'signature_country',
   field: 'signature_text',
   operator: 'in',
@@ -185,6 +229,53 @@ testInscriptionSearch({
   expectedCount: 4049,
   firstResultCheck: 'Öl 1',
   multiField: true,
+});
+
+
+testSingleRuleSearch({
+  field: 'carver',
+  operator: 'is_empty',
+  value: null,
+  expectedCount: 5735,
+  firstResultCheck: '',
+});
+testSingleRuleSearch({
+  field: 'carver',
+  operator: 'is_not_empty',
+  value: null,
+  expectedCount: 1080,
+  firstResultCheck: 'Nilsson attribuerar stenen till Korp.',
+});
+testSingleRuleSearch({
+  field: 'carver',
+  operator: 'equal',
+  value: 'Nilsson attribuerar stenen till Korp.',
+  expectedCount: 3,
+  firstResultCheck: 'Nilsson attribuerar stenen till Korp.',
+});
+
+
+testSingleRuleSearch({
+  id: 'cross_form',
+  field: 'crosses',
+  operator: 'cross_form',
+  value: {
+    form: 'B1',
+    is_certain: "1",
+  },
+  expectedCount: 662,
+  multiField: false,
+  firstResultCheck: JSON.parse('[[[],[{"name":"A4","isCertain":1}],[{"name":"B1","isCertain":1}],[{"name":"C9","isCertain":1},{"name":"C10","isCertain":1}],[{"name":"D5","isCertain":1}],[{"name":"E5","isCertain":1}],[{"name":"F3","isCertain":1}],[]]]'),
+});
+
+
+testSingleRuleSearch({
+  field: 'year_from',
+  operator: 'equal',
+  value: 1100,
+  expectedCount: 1876,
+  multiField: false,
+  firstResultCheck: 1100,
 });
 
 test.run();


### PR DESCRIPTION
* Fix importing search rules that include search via multiple inscription IDs
* Fix how search with year_from/year_to is done with respect to missing values. Before, inscription with values [1599; None] would be returned for search [greater 1000; less 1002]. Not anymore.
* Add full address to search rules. One can search without specifying parish, municipality, e.t.c.
* Add more unit tests