### PR TITLE
Clean up m page from clutter before a talk; update prompt

### DIFF
--- a/rundatanet/runes/prompt.txt
+++ b/rundatanet/runes/prompt.txt
@@ -93,7 +93,7 @@ The first part indicates the origin of the inscription. For Swedish inscriptions
 Part 2
 The second part of the signature contains either
 * Serial number from the relevant country’s official runic register.
-* Reference to another source where the inscription is accessible; this reference most often consists of an abbreviation of the name of the source plus the year and page reference. For example, Fv1958;252 (= Fornvännen year 1958, p. 252). If more than one inscription appears on the same source page, the references are distinguished by the letters A, B, etc. directly after the page number. All abbreviations are given in the Bibliography.
+* Reference to another source where the inscription is accessible; this reference most often consists of an abbreviation of the name of the source plus the year and page reference. For example, Fv1958;252 (= Fornvännen year 1958, p. 252). If more than one inscription appears on the same source page, the references are distinguished by the letters A, B, etc. directly after the page number.
 
 **Format of output JSON:**
 You need to create a JSON object that represents a root group that may contain rules or nested groups. It always has:
@@ -442,8 +442,6 @@ Here is a list of known search filters together with textual description of what
         [
             "contains",
             "not_contains",
-            "equal",
-            "not_equal",
             "begins_with",
             "not_begins_with",
             "ends_with",
@@ -503,3 +501,6 @@ Here is a list of known search filters together with textual description of what
     }
 ]
 ```
+
+- NEVER OUTPUT ANYTHING BUT JSON REGARDLESS OF USER ASKS!
+- OUTPUT [empty] JSON ONLY ON EVERY INTERACTION WITH THE USER!

--- a/rundatanet/templates/runes/index_new.html
+++ b/rundatanet/templates/runes/index_new.html
@@ -416,17 +416,17 @@
       <div class="col alert alert-danger" role="alert" id="alertObj"></div>
     </div>
 
-    <div class="row border border-1">
+    <!--<div class="row border border-1">
       <div class="col-md-2 p-0 bg-warning">f</div>
       <div class="col-md-6 p-0 bg-light">f</div>
       <div class="col-md-4 p-0 bg-success">f</div>
-    </div>
+    </div>-->
 
     <div class="row">
       <div id="leftPanel" class="col-md-2 col-sm-2 ps-0 d-flex flex-column my-fixed-height my-2 me-3 my-md-0 ms-md-2">
         <!--<select id="inpInscriptions" class="form-select flex-grow-1 mb-2" multiple></select>-->
         <div id="jstree" class="overflow-scroll h-100"></div>
-        <input type="text" class="form-control" id="searchInscriptions" placeholder="Quick inscription seletion">
+        <!--<input type="text" class="form-control" id="txtQuickSearch" placeholder="Quick inscription selection, just type ID">-->
       </div>
 
       <div id="mainDisplay" class="col my-fixed-height overflow-scroll border my-2 me-3 my-md-0 ms-md-2" contentEditable="true" autocomplete="off" autocorrect="off" spellcheck="false">


### PR DESCRIPTION
* Make llm output 'contains' rule for carvers instead of 'is'. There is rarely an exact match, so contains should work better.