### PR TITLE
Pin tom-select down to patch version

### DIFF
--- a/rundatanet/templates/runes/index.html
+++ b/rundatanet/templates/runes/index.html
@@ -687,7 +687,7 @@ function isSafari() {
 <script src="{% static 'runes/multiselect.min.js' %}"></script>
 
 <!-- begin of query builder js -->
-<script src="https://cdn.jsdelivr.net/npm/tom-select@2.4/dist/js/tom-select.complete.min.js" integrity="sha256-t5cAXPIzePs4RIuA3FejMxOlxXe4QXZXQ7sfKJxNU+Y=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/tom-select@2.4.6/dist/js/tom-select.complete.min.js" integrity="sha256-A9U5/68sW3UzwcjnX2L3nn/gbK3gQoch3TnpkGJKenk=" crossorigin="anonymous"></script>
 <script src="{% static 'runes/jquery.tom-select.js' %}"></script>
 <script src="https://cdn.jsdelivr.net/npm/interactjs@1.10.27/dist/interact.min.js" integrity="sha256-mbK9O9BSYbD9/9uBHmA1oo2AuLgeZ8+aIo53go9GwyY=" crossorigin="anonymous"></script>
 <!-- <script src="https://cdnjs.cloudflare.com/ajax/libs/select2/4.0.13/js/select2.min.js" integrity="sha512-2ImtlRlf2VVmiGZsjm9bEyhjGW4dU7B6TNwh/hx/iSByxNENtj3WVE6o/9Lj4TJeVXPi4bnOIMXFIJJAeufa0A==" crossorigin="anonymous" referrerpolicy="no-referrer"></script> -->


### PR DESCRIPTION
* Tom-select was referenced with hash as v2.4. However, when a newer version came out (2.4.6), the hash became invalid. This resulted in malfunction website.