### PR TITLE
Add robots.txt and enforce HTTPS protocol in sitemaps

### DIFF
--- a/rundatanet/runes/sitemaps.py
+++ b/rundatanet/runes/sitemaps.py
@@ -6,6 +6,7 @@ from .normalization import normalize_signature
 
 
 class StaticViewSitemap(sitemaps.Sitemap):
+    protocol = "https"
     priority = 0.2
     changefreq = "yearly"
 
@@ -17,6 +18,7 @@ class StaticViewSitemap(sitemaps.Sitemap):
 
 
 class MainPageSitemap(sitemaps.Sitemap):
+    protocol = "https"
     priority = 1.0
     changefreq = "weekly"
 
@@ -28,6 +30,7 @@ class MainPageSitemap(sitemaps.Sitemap):
 
 
 class AboutPageSitemap(sitemaps.Sitemap):
+    protocol = "https"
     priority = 0.4
     changefreq = "yearly"
 
@@ -39,6 +42,7 @@ class AboutPageSitemap(sitemaps.Sitemap):
 
 
 class InscriptionSitemap(sitemaps.Sitemap):
+    protocol = "https"
     priority = 0.8
     changefreq = "monthly"
 

--- a/rundatanet/runes/urls.py
+++ b/rundatanet/runes/urls.py
@@ -41,4 +41,9 @@ urlpatterns = [
     path("eda/", TemplateView.as_view(template_name="runes/eda.html"), name="eda"),
     path("inscription/<sig:slug>/", views.inscription_detail, name="inscription_detail"),
     path("sitemap.xml", sitemap, {"sitemaps": sitemaps}, name="django.contrib.sitemaps.views.sitemap"),
+    path(
+        "robots.txt",
+        TemplateView.as_view(template_name="robots.txt", content_type="text/plain"),
+        name="robots_txt",
+    ),
 ]

--- a/rundatanet/templates/robots.txt
+++ b/rundatanet/templates/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://rundata.info/sitemap.xml


### PR DESCRIPTION
- Add robots.txt with Sitemap directive pointing to sitemap.xml
- Set protocol = "https" on all Sitemap classes to ensure HTTPS URLs regardless of proxy header detection
- Fixes "Sitemap could not be read" error in Google Search Console