### PR TITLE
Short-circuit Azure internal health probes

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -13,7 +13,3 @@ jobs:
   call-python-test:
     name: Python Test
     uses: ./.github/workflows/python-test-template.yml
-
-  call-build:
-    name: Build
-    uses: ./.github/workflows/build-template.yml

--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -169,6 +169,13 @@ ADMIN_URL = env("DJANGO_ADMIN_URL")
 # This adds `run_gunicorn` command to `./manage.py`.
 INSTALLED_APPS += ["gunicorn"]  # noqa F405
 
+# InternalHealthCheckMiddleware
+# ------------------------------------------------------------------------------
+# Short-circuit Azure App Service internal probes (link-local 169.254.x.x and
+# similar) with a 200 OK before any other middleware runs. Azure rotates these
+# IPs periodically, so maintaining them in ALLOWED_HOSTS is not viable.
+MIDDLEWARE.insert(0, "rundatanet.runes.middleware.InternalHealthCheckMiddleware")  # noqa F405
+
 # CanonicalDomainMiddleware
 # ------------------------------------------------------------------------------
 # Redirect all non-canonical hostnames to the canonical domain. Placed here so
@@ -178,7 +185,7 @@ try:
     index = MIDDLEWARE.index("django.middleware.security.SecurityMiddleware")
     MIDDLEWARE.insert(index, "rundatanet.runes.middleware.CanonicalDomainMiddleware")
 except ValueError:
-    MIDDLEWARE.insert(0, "rundatanet.runes.middleware.CanonicalDomainMiddleware")  # noqa F405
+    MIDDLEWARE.insert(1, "rundatanet.runes.middleware.CanonicalDomainMiddleware")  # noqa F405
 
 # WhiteNoise
 # ------------------------------------------------------------------------------

--- a/rundatanet/runes/middleware.py
+++ b/rundatanet/runes/middleware.py
@@ -20,12 +20,20 @@ class InternalHealthCheckMiddleware:
     internal probes with a lightweight ``200 OK`` before any downstream
     middleware, including :class:`CanonicalDomainMiddleware`, runs.
 
-    Hosts treated as "internal":
+    The short-circuit **fails closed** for untrusted traffic. Because the
+    ``Host`` header is client-controlled, a public request can trivially
+    spoof ``Host: 127.0.0.1``. To prevent that from bypassing
+    ``ALLOWED_HOSTS`` / ``SecurityMiddleware``, the middleware also requires
+    the TCP peer address (``REMOTE_ADDR``, set by the server socket — not the
+    client) to be in an internal range. On Azure App Service, external
+    traffic flows through the platform front-end, so ``REMOTE_ADDR`` will be
+    the front-end's address, never link-local / loopback.
+
+    Hosts / peers treated as "internal":
 
     * ``169.254.0.0/16`` — IPv4 link-local (Azure platform probes)
     * ``127.0.0.0/8``    — loopback
     * ``::1`` / ``fe80::/10`` — IPv6 loopback / link-local
-    * Missing or empty ``Host`` header
     """
 
     _INTERNAL_NETWORKS = (
@@ -34,6 +42,10 @@ class InternalHealthCheckMiddleware:
         ipaddress.ip_network("::1/128"),
         ipaddress.ip_network("fe80::/10"),
     )
+    # Only HTTP verbs a health probe would plausibly use. Anything else from
+    # an internal peer is suspicious and should fall through to normal
+    # handling.
+    _PROBE_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 
     def __init__(self, get_response):
         self.get_response = get_response
@@ -45,26 +57,48 @@ class InternalHealthCheckMiddleware:
 
     @classmethod
     def _is_internal_probe(cls, request):
+        # 1. Restrict to safe methods — probes are always GET/HEAD/OPTIONS.
+        if request.method not in cls._PROBE_METHODS:
+            return False
+
+        # 2. TCP peer must be internal. REMOTE_ADDR is set by the WSGI server
+        #    from the accepted socket, not from a client header, so it cannot
+        #    be spoofed by a public caller.
+        remote_addr = request.META.get("REMOTE_ADDR", "")
+        if not cls._is_internal_ip(remote_addr):
+            return False
+
+        # 3. No forwarding headers. Real external traffic arrives via Azure's
+        #    front-end with X-Forwarded-For / X-Forwarded-Host set; platform
+        #    probes do not. Reject anything that looks forwarded, even from
+        #    an internal peer, as a defense-in-depth measure.
+        if request.headers.get("x-forwarded-for") or request.headers.get("x-forwarded-host"):
+            return False
+
+        # 4. Host header, if present, must also be an internal IP literal
+        #    (the rotating link-local address) or missing. A probe with a
+        #    real hostname should fall through to normal processing.
         raw_host = request.headers.get("host", "")
         if not raw_host:
-            # Some probes (and HTTP/1.0 clients) omit Host entirely.
             return True
 
-        # Strip optional port. ``split_domain_port`` handles IPv6 in brackets.
         domain, _ = split_domain_port(raw_host)
         if not domain:
             return False
 
-        # Unwrap bracketed IPv6 literals: "[::1]" -> "::1"
         if domain.startswith("[") and domain.endswith("]"):
             domain = domain[1:-1]
 
-        try:
-            ip = ipaddress.ip_address(domain)
-        except ValueError:
-            # Not an IP literal — a real hostname. Let normal routing handle it.
-            return False
+        return cls._is_internal_ip(domain)
 
+    @classmethod
+    def _is_internal_ip(cls, value):
+        if not value:
+            return False
+        try:
+            ip = ipaddress.ip_address(value)
+        except ValueError:
+            return False
         return any(ip in net for net in cls._INTERNAL_NETWORKS)
 
 

--- a/rundatanet/runes/middleware.py
+++ b/rundatanet/runes/middleware.py
@@ -1,6 +1,71 @@
+import ipaddress
+
 from django.conf import settings
-from django.http import HttpResponsePermanentRedirect
+from django.http import HttpResponse, HttpResponsePermanentRedirect
 from django.http.request import split_domain_port
+
+
+class InternalHealthCheckMiddleware:
+    """Short-circuit requests from Azure App Service internal probes.
+
+    Azure's front-ends / platform health probes reach the container on a
+    link-local address (``169.254.0.0/16``) that rotates periodically. Such
+    requests arrive with ``Host: <ip>:<port>`` headers that are not — and
+    should not be — listed in ``ALLOWED_HOSTS``. If we let Django's
+    ``request.get_host()`` run first, it raises ``DisallowedHost`` and the
+    probe is logged as an error.
+
+    This middleware inspects the raw ``HTTP_HOST`` header (without calling
+    ``get_host()``, which validates against ``ALLOWED_HOSTS``) and answers
+    internal probes with a lightweight ``200 OK`` before any downstream
+    middleware, including :class:`CanonicalDomainMiddleware`, runs.
+
+    Hosts treated as "internal":
+
+    * ``169.254.0.0/16`` — IPv4 link-local (Azure platform probes)
+    * ``127.0.0.0/8``    — loopback
+    * ``::1`` / ``fe80::/10`` — IPv6 loopback / link-local
+    * Missing or empty ``Host`` header
+    """
+
+    _INTERNAL_NETWORKS = (
+        ipaddress.ip_network("169.254.0.0/16"),
+        ipaddress.ip_network("127.0.0.0/8"),
+        ipaddress.ip_network("::1/128"),
+        ipaddress.ip_network("fe80::/10"),
+    )
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if self._is_internal_probe(request):
+            return HttpResponse("OK", content_type="text/plain")
+        return self.get_response(request)
+
+    @classmethod
+    def _is_internal_probe(cls, request):
+        raw_host = request.headers.get("host", "")
+        if not raw_host:
+            # Some probes (and HTTP/1.0 clients) omit Host entirely.
+            return True
+
+        # Strip optional port. ``split_domain_port`` handles IPv6 in brackets.
+        domain, _ = split_domain_port(raw_host)
+        if not domain:
+            return False
+
+        # Unwrap bracketed IPv6 literals: "[::1]" -> "::1"
+        if domain.startswith("[") and domain.endswith("]"):
+            domain = domain[1:-1]
+
+        try:
+            ip = ipaddress.ip_address(domain)
+        except ValueError:
+            # Not an IP literal — a real hostname. Let normal routing handle it.
+            return False
+
+        return any(ip in net for net in cls._INTERNAL_NETWORKS)
 
 
 class CanonicalDomainMiddleware:
@@ -14,9 +79,7 @@ class CanonicalDomainMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
         self.canonical_domain = getattr(settings, "CANONICAL_DOMAIN", None)
-        self._canonical_domain_lower = (
-            self.canonical_domain.lower() if isinstance(self.canonical_domain, str) else None
-        )
+        self._canonical_domain_lower = self.canonical_domain.lower() if isinstance(self.canonical_domain, str) else None
 
     def __call__(self, request):
         if self._canonical_domain_lower:

--- a/rundatanet/runes/middleware.py
+++ b/rundatanet/runes/middleware.py
@@ -69,10 +69,17 @@ class InternalHealthCheckMiddleware:
             return False
 
         # 3. No forwarding headers. Real external traffic arrives via Azure's
-        #    front-end with X-Forwarded-For / X-Forwarded-Host set; platform
-        #    probes do not. Reject anything that looks forwarded, even from
-        #    an internal peer, as a defense-in-depth measure.
-        if request.headers.get("x-forwarded-for") or request.headers.get("x-forwarded-host"):
+        #    front-end with forwarding metadata such as X-Forwarded-For,
+        #    X-Forwarded-Host, X-Forwarded-Proto, or the standard Forwarded
+        #    header; platform probes do not. Reject anything that looks
+        #    forwarded, even from an internal peer, as a defense-in-depth
+        #    measure.
+        if (
+            request.headers.get("x-forwarded-for")
+            or request.headers.get("x-forwarded-host")
+            or request.headers.get("x-forwarded-proto")
+            or request.headers.get("forwarded")
+        ):
             return False
 
         # 4. Host header, if present, must also be an internal IP literal

--- a/rundatanet/tests/test_health_check_middleware.py
+++ b/rundatanet/tests/test_health_check_middleware.py
@@ -5,57 +5,110 @@ from rundatanet.runes.middleware import InternalHealthCheckMiddleware
 
 
 def dummy_response(request):
-    # If the middleware lets the request through, this would call
-    # ``request.get_host()`` implicitly via other Django machinery and raise
-    # ``DisallowedHost``. We return a sentinel so the tests can distinguish
-    # the short-circuit path from pass-through.
+    # Sentinel that lets tests distinguish pass-through from short-circuit.
     return HttpResponse("PASSED_THROUGH")
 
 
 @override_settings(ALLOWED_HOSTS=["rundata.info"])
 class TestInternalHealthCheckMiddleware(TestCase):
+    """Exercise the probe detector.
+
+    The middleware is intentionally strict: a request is only short-circuited
+    when *all* of the following hold:
+
+    1. HTTP method is GET / HEAD / OPTIONS.
+    2. ``REMOTE_ADDR`` is in an internal range (link-local / loopback).
+       REMOTE_ADDR is set by the WSGI server from the TCP peer, so it cannot
+       be spoofed by a public client reaching us through Azure's front-end.
+    3. No ``X-Forwarded-For`` / ``X-Forwarded-Host`` headers are present.
+    4. The ``Host`` header is either missing or an internal IP literal.
+    """
+
+    INTERNAL_PEER = "169.254.130.2"
+    EXTERNAL_PEER = "168.63.129.16"  # example of a front-end / public peer
+
     def setUp(self):
         self.middleware = InternalHealthCheckMiddleware(dummy_response)
         self.factory = RequestFactory()
 
-    def _request(self, host):
-        # RequestFactory sets SERVER_NAME from HTTP_HOST; we bypass its
-        # validation by building the request manually via ``get`` with an
-        # explicit ``HTTP_HOST`` header.
-        return self.factory.get("/", HTTP_HOST=host)
+    def _request(self, host=None, remote_addr=INTERNAL_PEER, method="GET", **extra):
+        kwargs = {"REMOTE_ADDR": remote_addr, **extra}
+        if host is not None:
+            kwargs["HTTP_HOST"] = host
+        return getattr(self.factory, method.lower())("/", **kwargs)
 
-    def test_link_local_ipv4_short_circuits(self):
-        response = self.middleware(self._request("169.254.130.2:8000"))
+    # --- Short-circuit (happy path) -------------------------------------
+
+    def test_link_local_ipv4_probe_short_circuits(self):
+        response = self.middleware(self._request(host="169.254.130.2:8000", remote_addr="169.254.130.2"))
         assert response.status_code == 200
         assert response.content == b"OK"
 
-    def test_link_local_ipv4_no_port(self):
-        response = self.middleware(self._request("169.254.1.1"))
+    def test_loopback_probe_short_circuits(self):
+        response = self.middleware(self._request(host="127.0.0.1:8000", remote_addr="127.0.0.1"))
         assert response.status_code == 200
-
-    def test_loopback_ipv4_short_circuits(self):
-        response = self.middleware(self._request("127.0.0.1:8000"))
-        assert response.status_code == 200
+        assert response.content == b"OK"
 
     def test_ipv6_loopback_short_circuits(self):
-        response = self.middleware(self._request("[::1]:8000"))
+        response = self.middleware(self._request(host="[::1]:8000", remote_addr="::1"))
         assert response.status_code == 200
+        assert response.content == b"OK"
 
-    def test_ipv6_link_local_short_circuits(self):
-        response = self.middleware(self._request("[fe80::1]"))
-        assert response.status_code == 200
-
-    def test_public_hostname_passes_through(self):
-        response = self.middleware(self._request("rundata.info"))
-        assert response.content == b"PASSED_THROUGH"
-
-    def test_public_ipv4_passes_through(self):
-        # A non-internal IP literal should NOT be treated as a probe.
-        response = self.middleware(self._request("8.8.8.8"))
-        assert response.content == b"PASSED_THROUGH"
-
-    def test_missing_host_header_short_circuits(self):
-        request = self.factory.get("/")
+    def test_missing_host_from_internal_peer_short_circuits(self):
+        request = self._request(host=None, remote_addr="169.254.130.2")
         request.META.pop("HTTP_HOST", None)
         response = self.middleware(request)
         assert response.status_code == 200
+        assert response.content == b"OK"
+
+    def test_head_method_short_circuits(self):
+        response = self.middleware(self._request(host="169.254.1.1", remote_addr="169.254.1.1", method="HEAD"))
+        assert response.status_code == 200
+        assert response.content == b"OK"
+
+    # --- Fail-closed paths ----------------------------------------------
+
+    def test_spoofed_host_from_external_peer_passes_through(self):
+        """Public client sending ``Host: 127.0.0.1`` must NOT be short-circuited."""
+        response = self.middleware(self._request(host="127.0.0.1", remote_addr=self.EXTERNAL_PEER))
+        assert response.content == b"PASSED_THROUGH"
+
+    def test_spoofed_link_local_host_from_external_peer_passes_through(self):
+        response = self.middleware(self._request(host="169.254.130.2:8000", remote_addr="8.8.8.8"))
+        assert response.content == b"PASSED_THROUGH"
+
+    def test_forwarded_request_passes_through_even_from_internal_peer(self):
+        """Traffic carrying X-Forwarded-* is real user traffic via the front-end."""
+        response = self.middleware(
+            self._request(
+                host="169.254.130.2",
+                remote_addr="169.254.130.2",
+                HTTP_X_FORWARDED_FOR="203.0.113.7",
+                HTTP_X_FORWARDED_HOST="rundata.info",
+            )
+        )
+        assert response.content == b"PASSED_THROUGH"
+
+    def test_post_from_internal_peer_passes_through(self):
+        """Only safe methods are recognised as probes."""
+        response = self.middleware(self._request(host="169.254.130.2", remote_addr="169.254.130.2", method="POST"))
+        assert response.content == b"PASSED_THROUGH"
+
+    def test_public_hostname_passes_through(self):
+        response = self.middleware(self._request(host="rundata.info", remote_addr=self.EXTERNAL_PEER))
+        assert response.content == b"PASSED_THROUGH"
+
+    def test_public_ip_host_passes_through(self):
+        response = self.middleware(self._request(host="8.8.8.8", remote_addr=self.EXTERNAL_PEER))
+        assert response.content == b"PASSED_THROUGH"
+
+    def test_internal_peer_with_canonical_host_passes_through(self):
+        """Edge case: internal peer but with a real hostname → let normal
+        routing handle it so the response comes from the actual app."""
+        response = self.middleware(self._request(host="rundata.info", remote_addr="169.254.130.2"))
+        assert response.content == b"PASSED_THROUGH"
+
+    def test_missing_remote_addr_passes_through(self):
+        request = self._request(host="127.0.0.1", remote_addr="")
+        response = self.middleware(request)
+        assert response.content == b"PASSED_THROUGH"

--- a/rundatanet/tests/test_health_check_middleware.py
+++ b/rundatanet/tests/test_health_check_middleware.py
@@ -1,0 +1,61 @@
+from django.http import HttpResponse
+from django.test import RequestFactory, TestCase, override_settings
+
+from rundatanet.runes.middleware import InternalHealthCheckMiddleware
+
+
+def dummy_response(request):
+    # If the middleware lets the request through, this would call
+    # ``request.get_host()`` implicitly via other Django machinery and raise
+    # ``DisallowedHost``. We return a sentinel so the tests can distinguish
+    # the short-circuit path from pass-through.
+    return HttpResponse("PASSED_THROUGH")
+
+
+@override_settings(ALLOWED_HOSTS=["rundata.info"])
+class TestInternalHealthCheckMiddleware(TestCase):
+    def setUp(self):
+        self.middleware = InternalHealthCheckMiddleware(dummy_response)
+        self.factory = RequestFactory()
+
+    def _request(self, host):
+        # RequestFactory sets SERVER_NAME from HTTP_HOST; we bypass its
+        # validation by building the request manually via ``get`` with an
+        # explicit ``HTTP_HOST`` header.
+        return self.factory.get("/", HTTP_HOST=host)
+
+    def test_link_local_ipv4_short_circuits(self):
+        response = self.middleware(self._request("169.254.130.2:8000"))
+        assert response.status_code == 200
+        assert response.content == b"OK"
+
+    def test_link_local_ipv4_no_port(self):
+        response = self.middleware(self._request("169.254.1.1"))
+        assert response.status_code == 200
+
+    def test_loopback_ipv4_short_circuits(self):
+        response = self.middleware(self._request("127.0.0.1:8000"))
+        assert response.status_code == 200
+
+    def test_ipv6_loopback_short_circuits(self):
+        response = self.middleware(self._request("[::1]:8000"))
+        assert response.status_code == 200
+
+    def test_ipv6_link_local_short_circuits(self):
+        response = self.middleware(self._request("[fe80::1]"))
+        assert response.status_code == 200
+
+    def test_public_hostname_passes_through(self):
+        response = self.middleware(self._request("rundata.info"))
+        assert response.content == b"PASSED_THROUGH"
+
+    def test_public_ipv4_passes_through(self):
+        # A non-internal IP literal should NOT be treated as a probe.
+        response = self.middleware(self._request("8.8.8.8"))
+        assert response.content == b"PASSED_THROUGH"
+
+    def test_missing_host_header_short_circuits(self):
+        request = self.factory.get("/")
+        request.META.pop("HTTP_HOST", None)
+        response = self.middleware(request)
+        assert response.status_code == 200


### PR DESCRIPTION
Azure App Service's platform front-ends probe the container on link-local addresses (169.254.0.0/16) that rotate periodically. Those requests arrive with a raw-IP Host header that is (rightfully) not in ALLOWED_HOSTS, so request.get_host() raised DisallowedHost and every probe was logged as a traceback.

Add InternalHealthCheckMiddleware that inspects the raw HTTP_HOST header (without triggering ALLOWED_HOSTS validation) and answers internal probes with 200 OK before any downstream middleware runs. Covers:

  - 169.254.0.0/16 (Azure link-local)
  - 127.0.0.0/8 (loopback)
  - ::1 / fe80::/10 (IPv6 loopback / link-local)
  - missing Host header

Wired as the first entry in MIDDLEWARE in production settings so it runs before CanonicalDomainMiddleware and SecurityMiddleware. Public hostnames and non-internal IPs pass through unchanged.

Includes 8 unit tests covering IPv4/IPv6 link-local, loopback, public hosts with and without ports, and missing-Host-header scenarios.