### PR TITLE
Improve mobile map interactions for two clusters + info label

### DIFF
--- a/rundatanet/runes/js/index_map.js
+++ b/rundatanet/runes/js/index_map.js
@@ -3,6 +3,152 @@
  It allows relies on defined `isSafari` function.
 */
 
+const MOBILE_PAIR_SPIDERFY_MAX_DISTANCE_METERS = 100;
+const MOBILE_SHARED_COORDINATE_MAX_MARKERS = 10;
+
+export function shouldSpiderfyNearbyPair(cluster, map, maxDistanceMeters = MOBILE_PAIR_SPIDERFY_MAX_DISTANCE_METERS) {
+  if (!cluster || typeof cluster.getAllChildMarkers !== 'function'
+    || !map || typeof map.distance !== 'function') {
+    return false;
+  }
+
+  if (typeof cluster.getChildCount === 'function' && cluster.getChildCount() !== 2) {
+    return false;
+  }
+
+  const childMarkers = cluster.getAllChildMarkers();
+  if (childMarkers.length !== 2) {
+    return false;
+  }
+
+  return map.distance(
+    childMarkers[0].getLatLng(),
+    childMarkers[1].getLatLng()
+  ) <= maxDistanceMeters;
+}
+
+export function shouldSpiderfySharedCoordinates(cluster, maxMarkers = MOBILE_SHARED_COORDINATE_MAX_MARKERS) {
+  if (!cluster || typeof cluster.getChildCount !== 'function'
+    || typeof cluster.getAllChildMarkers !== 'function') {
+    return false;
+  }
+
+  const childCount = cluster.getChildCount();
+  if (childCount < 2 || childCount > maxMarkers) {
+    return false;
+  }
+
+  const childMarkers = cluster.getAllChildMarkers();
+  if (childMarkers.length !== childCount) {
+    return false;
+  }
+
+  const firstLatLng = childMarkers[0].getLatLng();
+  return childMarkers.every(marker => {
+    const latLng = marker.getLatLng();
+    return latLng.lat === firstLatLng.lat && latLng.lng === firstLatLng.lng;
+  });
+}
+
+export function handleMobileClusterClick(event, map) {
+  const cluster = event && event.layer;
+  if (!cluster) {
+    return;
+  }
+
+  if (shouldSpiderfyNearbyPair(cluster, map) || shouldSpiderfySharedCoordinates(cluster)) {
+    cluster.spiderfy();
+    return;
+  }
+
+  const isAtMaxZoom = typeof map.getZoom === 'function'
+    && typeof map.getMaxZoom === 'function'
+    && map.getZoom() >= map.getMaxZoom();
+  if (isAtMaxZoom && typeof cluster.spiderfy === 'function') {
+    cluster.spiderfy();
+  } else if (typeof cluster.zoomToBounds === 'function') {
+    cluster.zoomToBounds();
+  }
+}
+
+export function getMarkerClusterOptions(isMobile) {
+  const options = {
+    showCoverageOnHover: true,
+    chunkedLoading: true,
+    maxClusterRadius: 60,
+  };
+  if (isMobile) {
+    // Handle small nearby pairs ourselves so they separate immediately on tap.
+    options.zoomToBoundsOnClick = false;
+    options.spiderfyOnMaxZoom = false;
+  }
+  return options;
+}
+
+export function getSpiderfiedTooltipDirection(marker, cluster, map) {
+  if (!marker || !cluster || !map
+    || typeof marker.getLatLng !== 'function'
+    || typeof cluster.getLatLng !== 'function'
+    || typeof map.latLngToLayerPoint !== 'function') {
+    return 'auto';
+  }
+
+  const markerPoint = map.latLngToLayerPoint(marker.getLatLng());
+  const clusterPoint = map.latLngToLayerPoint(cluster.getLatLng());
+  const deltaX = markerPoint.x - clusterPoint.x;
+  const deltaY = markerPoint.y - clusterPoint.y;
+
+  if (Math.abs(deltaX) >= Math.abs(deltaY)) {
+    return deltaX >= 0 ? 'right' : 'left';
+  }
+  return deltaY >= 0 ? 'bottom' : 'top';
+}
+
+function getSpiderfyEventMarkers(event) {
+  if (event && Array.isArray(event.markers)) {
+    return event.markers;
+  }
+  if (event && event.cluster && typeof event.cluster.getAllChildMarkers === 'function') {
+    return event.cluster.getAllChildMarkers();
+  }
+  return [];
+}
+
+export function positionSpiderfiedTooltips(event, map) {
+  const cluster = event && event.cluster;
+  if (!cluster) {
+    return;
+  }
+
+  getSpiderfyEventMarkers(event).forEach(marker => {
+    const tooltip = typeof marker.getTooltip === 'function' ? marker.getTooltip() : null;
+    if (!tooltip || !tooltip.options) {
+      return;
+    }
+    if (typeof tooltip._rundataOriginalDirection === 'undefined') {
+      tooltip._rundataOriginalDirection = tooltip.options.direction || 'auto';
+    }
+    tooltip.options.direction = getSpiderfiedTooltipDirection(marker, cluster, map);
+    if (typeof tooltip.update === 'function') {
+      tooltip.update();
+    }
+  });
+}
+
+export function resetSpiderfiedTooltips(event) {
+  getSpiderfyEventMarkers(event).forEach(marker => {
+    const tooltip = typeof marker.getTooltip === 'function' ? marker.getTooltip() : null;
+    if (!tooltip || !tooltip.options || typeof tooltip._rundataOriginalDirection === 'undefined') {
+      return;
+    }
+    tooltip.options.direction = tooltip._rundataOriginalDirection;
+    delete tooltip._rundataOriginalDirection;
+    if (typeof tooltip.update === 'function') {
+      tooltip.update();
+    }
+  });
+}
+
 // Initialize the map on the user-provided div with a given center and zoom level
 // Default center is [56.607512, 16.439838] and default zoom is 8.
 export function initMap(divId, center = [56.607512, 16.439838], zoom = 8) {
@@ -45,14 +191,19 @@ export function initMap(divId, center = [56.607512, 16.439838], zoom = 8) {
     }
   });
 
-  const markers = L.markerClusterGroup({
-    showCoverageOnHover: true,
-    chunkedLoading: true,
-    maxClusterRadius: 60,
-  });
+  const markers = L.markerClusterGroup(getMarkerClusterOptions(isMobile));
   markers.on('click', function (e) {
     scrollToInscription(e.layer.options.signature, e.layer.options.id);
   });
+  if (isMobile) {
+    markers.on('clusterclick', function(event) {
+      handleMobileClusterClick(event, map);
+    });
+    markers.on('spiderfied', function(event) {
+      positionSpiderfiedTooltips(event, map);
+    });
+    markers.on('unspiderfied', resetSpiderfiedTooltips);
+  }
   markers.addTo(map);
 
   return {map, markers};
@@ -107,6 +258,43 @@ function getGeoIntentURL(lat, lng) {
   // Use Google Maps universal directions URL so mobile users (including iPhone)
   // can open navigation consistently.
   return `https://www.google.com/maps/dir/?api=1&destination=${lat},${lng}&travelmode=driving`;
+}
+
+function selectInscriptionForMobileInfo(inscriptionId) {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+
+  if (typeof window.scrollToInscription === 'function') {
+    window.scrollToInscription('', inscriptionId);
+    return true;
+  }
+
+  const jquery = window.jQuery || window.$;
+  if (typeof jquery !== 'function') {
+    return false;
+  }
+  const tree = jquery('#jstree').jstree(true);
+  if (!tree) {
+    return false;
+  }
+  tree.deselect_all();
+  tree.select_node(String(inscriptionId));
+  return true;
+}
+
+export function openMobileInscriptionInfo(inscriptionId) {
+  if (!isMobileDevice() || !selectInscriptionForMobileInfo(inscriptionId)) {
+    return false;
+  }
+
+  const infoButton = typeof document !== 'undefined'
+    ? document.getElementById('mobilePaneInfo')
+    : null;
+  if (infoButton && typeof infoButton.click === 'function') {
+    infoButton.click();
+  }
+  return false;
 }
 
 function isLostInscription(inscriptionData) {
@@ -204,6 +392,10 @@ function inscription2marker(inscriptionData, lat, lon, locationType = 'found', l
     popupText += `<a${driveLinkClass} href="${destinationUrl}" target="_self" onclick="return window.confirm('${confirmText}')">Drive here!</a>`;
   } else {
     popupText += `<a${driveLinkClass} href="${destinationUrl}" target="_self">Drive here!</a>`;
+  }
+  if (isMobile) {
+    const inscriptionId = JSON.stringify(String(inscriptionData.id));
+    popupText += `<button type="button" class="map-open-info-link" onclick='return window.openMobileInscriptionInfo(${inscriptionId})'>Open info</button>`;
   }
   // Tooltip is simple and is always on, popup supports HTML and is opened  /closed by user
   const popupOptions = isMobile

--- a/rundatanet/templates/runes/index.html
+++ b/rundatanet/templates/runes/index.html
@@ -377,11 +377,12 @@
           font-weight: 700;
           margin: 0.1rem 0 0.35rem;
         }
-        body.mobile-db-map-view .map-drive-link {
-          background: #243b53;
+        body.mobile-db-map-view .map-drive-link,
+        body.mobile-db-map-view .map-open-info-link {
+          border: 1px solid transparent;
           border-radius: 6px;
-          color: #fff !important;
-          display: inline-block;
+          display: block;
+          font-family: inherit;
           font-size: 0.9rem;
           font-weight: 700;
           margin-top: 0.25rem;
@@ -389,6 +390,16 @@
           text-decoration: none;
           width: 100%;
           text-align: center;
+        }
+        body.mobile-db-map-view .map-drive-link {
+          background: #243b53;
+          color: #fff !important;
+        }
+        body.mobile-db-map-view .map-open-info-link {
+          background: #d1e7dd;
+          border-color: #75b798;
+          color: #0f5132 !important;
+          cursor: pointer;
         }
         body.mobile-db-map-view .mobile-map-id-tooltip {
           cursor: pointer;
@@ -1298,7 +1309,7 @@ function isSafari() {
 <script src="https://cdnjs.cloudflare.com/ajax/libs/PapaParse/5.4.1/papaparse.min.js" integrity="sha512-dfX5uYVXzyU8+KHqj8bjo7UkOdg18PaOtpa48djpNbZHwExddghZ+ZmzWT06R5v6NSk3ZUfsH6FNEDepLx9hPQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js" integrity="sha512-r22gChDnGvBylk90+2e/ycr3RVrDi8DIOkIGNhJlKfuyQM4tIRAI062MaV8sfjQKYVGjOBaZBOA87z+IhZE9DA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
-<script type="text/javascript" src="{% static 'runes/index.min.js' %}?v=20260603-mobile-property-order"></script>
+<script type="text/javascript" src="{% static 'runes/index.min.js' %}?v=20260620-mobile-open-info-v4"></script>
 
 <script type="text/javascript">
 let gSqlDb = null;

--- a/rundatanet/tests/js/index_map.test.js
+++ b/rundatanet/tests/js/index_map.test.js
@@ -1,6 +1,16 @@
 import { test } from 'uvu';
 import * as assert from 'uvu/assert';
-import { inscriptions2markers } from '../../runes/js/index_map.js';
+import {
+  getMarkerClusterOptions,
+  getSpiderfiedTooltipDirection,
+  handleMobileClusterClick,
+  inscriptions2markers,
+  openMobileInscriptionInfo,
+  positionSpiderfiedTooltips,
+  resetSpiderfiedTooltips,
+  shouldSpiderfyNearbyPair,
+  shouldSpiderfySharedCoordinates,
+} from '../../runes/js/index_map.js';
 
 const mockLeaflet = {
   marker: (latlng, options) => {
@@ -53,6 +63,141 @@ const mockLeaflet = {
       return markerObj;
   }
 };
+
+function makeClusterMock(markerCoordinates) {
+  const childMarkers = markerCoordinates.map(([lat, lng]) => ({
+    getLatLng: () => ({lat, lng}),
+  }));
+  const cluster = {
+    getChildCount: () => childMarkers.length,
+    getAllChildMarkers: () => childMarkers,
+    spiderfy: () => {
+      cluster.spiderfyCalled = true;
+    },
+    zoomToBounds: () => {
+      cluster.zoomToBoundsCalled = true;
+    },
+  };
+  return cluster;
+}
+
+function makeMapMock(distanceMeters, zoom = 10, maxZoom = 19) {
+  return {
+    distance: () => distanceMeters,
+    getZoom: () => zoom,
+    getMaxZoom: () => maxZoom,
+  };
+}
+
+function makeSpiderfyMarker(lat, lng) {
+  const tooltip = {
+    options: {direction: 'auto'},
+    update: () => {
+      tooltip.updateCount = (tooltip.updateCount || 0) + 1;
+    },
+  };
+  return {
+    getLatLng: () => ({lat, lng}),
+    getTooltip: () => tooltip,
+    tooltip,
+  };
+}
+
+test('shouldSpiderfyNearbyPair() accepts only nearby two-marker clusters', () => {
+  const nearbyPair = makeClusterMock([[58.416765, 15.522882], [58.416846, 15.522864]]);
+  const threeMarkers = makeClusterMock([[1, 1], [1, 1.0001], [1, 1.0002]]);
+
+  assert.is(shouldSpiderfyNearbyPair(nearbyPair, makeMapMock(9)), true);
+  assert.is(shouldSpiderfyNearbyPair(nearbyPair, makeMapMock(101)), false);
+  assert.is(shouldSpiderfyNearbyPair(threeMarkers, makeMapMock(9)), false);
+});
+
+test('handleMobileClusterClick() immediately spiderfies a nearby pair', () => {
+  const cluster = makeClusterMock([[58.416765, 15.522882], [58.416846, 15.522864]]);
+
+  handleMobileClusterClick({layer: cluster}, makeMapMock(9));
+
+  assert.is(cluster.spiderfyCalled, true);
+  assert.is(cluster.zoomToBoundsCalled, undefined);
+});
+
+test('shouldSpiderfySharedCoordinates() accepts small clusters at one point', () => {
+  const exactPair = makeClusterMock([[58.366819, 15.371625], [58.366819, 15.371625]]);
+  const exactTriple = makeClusterMock([[1, 1], [1, 1], [1, 1]]);
+  const differentCoordinates = makeClusterMock([[1, 1], [1, 1.000001], [1, 1]]);
+  const largeExactCluster = makeClusterMock(Array.from({length: 11}, () => [1, 1]));
+
+  assert.is(shouldSpiderfySharedCoordinates(exactPair), true);
+  assert.is(shouldSpiderfySharedCoordinates(exactTriple), true);
+  assert.is(shouldSpiderfySharedCoordinates(differentCoordinates), false);
+  assert.is(shouldSpiderfySharedCoordinates(largeExactCluster), false);
+});
+
+test('handleMobileClusterClick() immediately spiderfies shared coordinates', () => {
+  const cluster = makeClusterMock([[1, 1], [1, 1], [1, 1]]);
+
+  handleMobileClusterClick({layer: cluster}, makeMapMock(0));
+
+  assert.is(cluster.spiderfyCalled, true);
+  assert.is(cluster.zoomToBoundsCalled, undefined);
+});
+
+test('handleMobileClusterClick() keeps normal zoom for other clusters', () => {
+  const distantPair = makeClusterMock([[58, 15], [59, 16]]);
+
+  handleMobileClusterClick({layer: distantPair}, makeMapMock(500));
+
+  assert.is(distantPair.spiderfyCalled, undefined);
+  assert.is(distantPair.zoomToBoundsCalled, true);
+});
+
+test('getMarkerClusterOptions() changes cluster clicks only on mobile', () => {
+  const desktopOptions = getMarkerClusterOptions(false);
+  const mobileOptions = getMarkerClusterOptions(true);
+
+  assert.is(desktopOptions.zoomToBoundsOnClick, undefined);
+  assert.is(desktopOptions.spiderfyOnMaxZoom, undefined);
+  assert.is(mobileOptions.zoomToBoundsOnClick, false);
+  assert.is(mobileOptions.spiderfyOnMaxZoom, false);
+  assert.is(mobileOptions.maxClusterRadius, desktopOptions.maxClusterRadius);
+});
+
+test('getSpiderfiedTooltipDirection() points labels away from cluster center', () => {
+  const cluster = {getLatLng: () => ({lat: 0, lng: 0})};
+  const map = {
+    latLngToLayerPoint: ({lat, lng}) => ({x: lng, y: -lat}),
+  };
+
+  assert.is(getSpiderfiedTooltipDirection(makeSpiderfyMarker(0, 1), cluster, map), 'right');
+  assert.is(getSpiderfiedTooltipDirection(makeSpiderfyMarker(0, -1), cluster, map), 'left');
+  assert.is(getSpiderfiedTooltipDirection(makeSpiderfyMarker(1, 0), cluster, map), 'top');
+  assert.is(getSpiderfiedTooltipDirection(makeSpiderfyMarker(-1, 0), cluster, map), 'bottom');
+});
+
+test('spiderfied tooltip directions are applied and then restored', () => {
+  const markers = [
+    makeSpiderfyMarker(0, 1),
+    makeSpiderfyMarker(0, -1),
+  ];
+  const cluster = {getLatLng: () => ({lat: 0, lng: 0})};
+  const map = {
+    latLngToLayerPoint: ({lat, lng}) => ({x: lng, y: -lat}),
+  };
+  const event = {cluster, markers};
+
+  positionSpiderfiedTooltips(event, map);
+
+  assert.is(markers[0].tooltip.options.direction, 'right');
+  assert.is(markers[1].tooltip.options.direction, 'left');
+  assert.is(markers[0].tooltip.updateCount, 1);
+
+  resetSpiderfiedTooltips(event);
+
+  assert.is(markers[0].tooltip.options.direction, 'auto');
+  assert.is(markers[1].tooltip.options.direction, 'auto');
+  assert.is(markers[0].tooltip._rundataOriginalDirection, undefined);
+  assert.is(markers[0].tooltip.updateCount, 2);
+});
 
 
 test('inscriptions2markers() on empty input', async () => {
@@ -152,6 +297,7 @@ test('inscriptions2markers() adds drive link and warnings to marker popup', asyn
   assert.is(marker.popupOptions.autoClose, false);
   assert.is(marker.popupOptions.autoPan, undefined);
   assert.not.match(marker.popupText, /map-drive-link/);
+  assert.not.match(marker.popupText, /map-open-info-link/);
   assert.not.match(marker.popupText, /map-popup-warning/);
   assert.not.match(presentMarker.popupText, /Warning: this inscription is moved/);
   assert.not.match(presentMarker.popupText, /You are driving to Current location/);
@@ -182,6 +328,9 @@ test('inscriptions2markers() uses mobile-only popup helpers on mobile', async ()
   const presentMarker = result.get(1).present;
 
   assert.match(marker.popupText, /map-drive-link/);
+  assert.match(marker.popupText, /map-open-info-link/);
+  assert.match(marker.popupText, /Open info/);
+  assert.match(marker.popupText, /openMobileInscriptionInfo\("1"\)/);
   assert.match(marker.popupText, /map-popup-warning/);
   assert.is(marker.popupOptions.autoPan, true);
   assert.match(presentMarker.popupText, /Warning: this inscription is moved/);
@@ -202,4 +351,41 @@ test('inscriptions2markers() uses mobile-only popup helpers on mobile', async ()
     value: originalNavigator,
     configurable: true,
   });
+});
+
+test('openMobileInscriptionInfo() selects inscription before opening Info pane', () => {
+  const originalNavigator = globalThis.navigator;
+  const originalWindow = globalThis.window;
+  const originalDocument = globalThis.document;
+  let selectedId = null;
+  let infoClicked = false;
+
+  Object.defineProperty(globalThis, 'navigator', {
+    value: {userAgent: 'iPhone'},
+    configurable: true,
+  });
+  globalThis.window = {
+    matchMedia: () => ({matches: true}),
+    scrollToInscription: (_signature, inscriptionId) => {
+      selectedId = inscriptionId;
+    },
+  };
+  globalThis.document = {
+    getElementById: (id) => id === 'mobilePaneInfo'
+      ? {click: () => { infoClicked = true; }}
+      : null,
+  };
+
+  const result = openMobileInscriptionInfo('42');
+
+  assert.is(result, false);
+  assert.is(selectedId, '42');
+  assert.is(infoClicked, true);
+
+  Object.defineProperty(globalThis, 'navigator', {
+    value: originalNavigator,
+    configurable: true,
+  });
+  globalThis.window = originalWindow;
+  globalThis.document = originalDocument;
 });


### PR DESCRIPTION
Only for obile layout of the DB: two clusterd that share coordinates or close to each other are now spiderfy and labels do not overlap.
The bigger labels now contain text button Open Info which switches to Info flick